### PR TITLE
KTOR-7909 docs: update Linux instructions in contributing.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,8 @@ system you use for development:
 Run the following commands to install `libcurl` and `libncurses`:
 
 ```bash
-sudo apt-get update
-sudo apt-get install libncurses5 libncursesw5 libtinfo5
-sudo apt-get install libcurl4-openssl-dev
+sudo apt update
+sudo apt install libncurses-dev libtinfo-dev libcurl4-openssl-dev
 ```
 
 **macOS** 


### PR DESCRIPTION
**Subsystem**
docs

**Motivation**
As a new contributor, the instructions to build from source have an old version of libncurses and will result in a package not found error.  This can be confusing to new contributors. 

**Solution**

- Replace outdated 'libncurses5' packages with 'libncurses-dev' and 'libtinfo-dev' to ensure compatibility future compatibility.

- Use 'apt' instead of 'apt-get' for modern best practices.

- Simplify installation commands by combining them and removing explicit version numbers.
